### PR TITLE
Update build & publish deps

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.10.2](https://github.com/dbader/pytest-mypy/milestone/20)
+* Update and loosen [build-system] requirements.
+
 ## [0.10.1](https://github.com/dbader/pytest-mypy/milestone/19)
 * Work around https://github.com/python/mypy/issues/14042.
 * Add support for Python 3.11.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools ~= 50.3.0', 'setuptools-scm[toml] ~= 5.0.0', 'wheel ~= 0.36.0']
-build-backend = 'setuptools.build_meta'
+requires = ["setuptools >= 59.6", "setuptools-scm[toml] >= 6.4", "wheel >= 0.37.1"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@ testpaths = tests
 [testenv:publish]
 passenv = TWINE_*
 deps =
-    build ~= 0.8.0
+    build[virtualenv] ~= 0.9.0
     twine ~= 4.0.0
 commands =
     {envpython} -m build --outdir {distdir} .


### PR DESCRIPTION
Resolve #147 

FWIW, the motivation for using `~=` in the `[build-system]` is so that the build for a given release continues to work even after backwards-incompatible changes to `setuptools`/etc. are published.

That said, the downstream has the option to downgrade if the build of an old release breaks, and loosening the pins can enable OS packagers who may not have access to PyPI / the pinned versions.