### PR TITLE
Simplify project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,12 +32,8 @@ requires-python = ">=3.7"
 dependencies = [
     "attrs>=19.0",
     "filelock>=3.0",
-    "pytest>=4.6; python_version<'3.10'",
-    "pytest>=6.2; python_version>='3.10'",
-    "mypy>=0.500; python_version<'3.8'",
-    "mypy>=0.700; python_version>='3.8' and python_version<'3.9'",
-    "mypy>=0.780; python_version>='3.9' and python_version<'3.11'",
-    "mypy>=0.900; python_version>='3.11'",
+    "mypy>=0.50",
+    "pytest>=4.6",
 ]
 
 [project.entry-points.pytest11]


### PR DESCRIPTION
We don't need to capture the requirements of other projects. For example, if mypy 0.50 were to work on Python 3.11, we would support it because we have to support it on Python 3.7 anyways. Moreover, simplifying these pins does not forego the ability to require newer versions of mypy/pytest as older versions of Python become unsupported.