### PR TITLE
Remove wheel as a build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.0", "setuptools-scm >= 7.1", "wheel >= 0.40"]
+requires = ["setuptools >= 61.0", "setuptools-scm >= 7.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Related: https://github.com/pypa/sampleproject/issues/203
> It's already pulled in by `setuptools` automatically, when building wheels is requested from the frontend. If only sdists are being build, `pyproject.toml` shouldn't forcefully inject this dependency into the ephemeral build env.